### PR TITLE
chore(ci) setup github actions CI

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,12 @@
+[bumpversion]
+current_version = 0.0.11
+commit = False
+tag = True
+tag_name = {new_version}
+message = Bump version: {current_version} -> {new_version}
+
+[semver]
+main_branches = main
+major_branches = major
+minor_branches = feature
+patch_branches = hotfix, bugfix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+      - name: Auto Increment Semver Action
+        uses: MCKanpolat/auto-semver-action@1.0.5
+        id: versioning
+        with:
+          releaseType: patch 
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Github Release
+        uses: actions/create-release@v1
+        if: steps['versioning']['outputs']['RETURN_STATUS'] == '0'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.versioning.outputs.version }}
+          release_name: ${{ steps.versioning.outputs.version }}
+          body: Version ${{ steps.versioning.outputs.version }}
+          draft: false
+          prerelease: false
+      - name: Update pulp-core pin
+        run: sed -i "s,FROM kong/pulp-core.*,FROM kong/pulp-core:${{ steps.versioning.outputs.version }},g" */Dockerfile
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build tagged images
+        env:
+          DOCKER_BUILDKIT: 1
+          ORG: kong
+          TAG: ${{ steps.versioning.outputs.version }}
+        run: |
+          make images
+      - name: Build latest images
+        env:
+          DOCKER_BUILDKIT: 1
+          ORG: kong
+          TAG: latest
+        run: |
+          make images
+      - name: Release latest images
+        env:
+          ORG: kong
+          TAG: latest
+        run: |
+          make release
+      - name: Release tagged images
+        env:
+          ORG: kong
+          TAG: ${{ steps.versioning.outputs.version }}
+        run: |
+          make release
+      - name: Commit back
+        uses: actions-js/push@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          message: Release ${{ steps.versioning.outputs.version }}
+          branch: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Update pulp-core pin
-        run: sed -i "s,FROM kong/pulp-core.*,FROM kong/pulp-core:${{ steps.versioning.outputs.version }},g" */Dockerfile
+        run: sed -i 's|FROM kong/pulp-core.*|FROM kong/pulp-core:${{ steps.versioning.outputs.version }}|g' */Dockerfile
       - name: Login to DockerHub
         uses: docker/login-action@v1 
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 ORG ?=
+TAG ?=
 
 images: build-pulp-core \
         build-pulp-api \
@@ -12,32 +13,11 @@ release: release-pulp-core \
          release-pulp-resource-manager \
          release-pulp-worker
 
-images-podman: build-podman-pulp-core \
-               build-podman-pulp-api \
-               build-podman-pulp-content \
-               build-podman-pulp-resource-manager \
-               build-podman-pulp-worker
-
-release-podman: release-podman-pulp-core \
-                release-podman-pulp-api \
-                release-podman-pulp-content \
-                release-podman-pulp-resource-manager \
-                release-podman-pulp-worker
-
-build-podman-%:
-	$(eval IMAGE := $(patsubst build-podman-%,%,$@))
-	sed -i "s,FROM kong/pulp-core,FROM $(ORG)pulp-core,g" $(IMAGE)/Dockerfile
-	cd $(IMAGE) && podman build --format=docker -t $(ORG)$(IMAGE) .
-
-release-podman-%:
-	$(eval IMAGE := $(patsubst release-podman-%,%,$@))
-	cd $(IMAGE) && podman push $(ORG)$(IMAGE)
-
 build-%:
 	$(eval IMAGE := $(patsubst build-%,%,$@))
-	sed -i "s,FROM kong/pulp-core,FROM $(ORG)pulp-core,g" $(IMAGE)/Dockerfile
-	cd $(IMAGE) && docker build -t $(ORG)$(IMAGE) .
+	sed -i "s,FROM pulp-core,FROM $(ORG)/pulp-core,g" $(IMAGE)/Dockerfile
+	cd $(IMAGE) && docker build --cache-from $(ORG)/$(IMAGE):latest -t $(ORG)/$(IMAGE):$(TAG) .
 
 release-%:
 	$(eval IMAGE := $(patsubst release-%,%,$@))
-	cd $(IMAGE) && docker push $(ORG)$(IMAGE)
+	cd $(IMAGE) && docker push $(ORG)/$(IMAGE):$(TAG)

--- a/pulp-api/Dockerfile
+++ b/pulp-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM kong/pulp-core
+FROM kong/pulp-core:0.0.7
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/pulp-content/Dockerfile
+++ b/pulp-content/Dockerfile
@@ -1,4 +1,4 @@
-FROM kong/pulp-core
+FROM kong/pulp-core:0.0.7
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/pulp-resource-manager/Dockerfile
+++ b/pulp-resource-manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM kong/pulp-core
+FROM kong/pulp-core:0.0.7
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/pulp-worker/Dockerfile
+++ b/pulp-worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM kong/pulp-core
+FROM kong/pulp-core:0.0.7
 
 ADD entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Tested here: https://github.com/hutchic/docker-pulp/actions/runs/657861001

This CI will create a github release, create a github tag, create docker images, push the docker images, update the Dockefile tag pin versions