### PR TITLE
Revert "Bump pyyaml from 5.3.1 to 5.4.1 in /pulp-core"

### DIFF
--- a/pulp-core/requirements.txt
+++ b/pulp-core/requirements.txt
@@ -70,7 +70,7 @@ python-dateutil==2.8.1
 python-debian==0.1.39
 python-gnupg==0.4.7
 pytz==2021.1
-PyYAML==5.4.1
+PyYAML==5.3.1
 redis==3.5.3
 requests==2.25.1
 rq==1.7.0


### PR DESCRIPTION
Reverts Kong/docker-pulp#7

pulp-core 5.10 depends upon pyyaml <= 5.4.0 for some reason.