### PR TITLE
Revert "Bump django-import-export from 2.4.0 to 2.5.0 in /pulp-core"

### DIFF
--- a/pulp-core/requirements.txt
+++ b/pulp-core/requirements.txt
@@ -29,7 +29,7 @@ django-currentuser==0.5.2
 django-filter==2.4.0
 django-guardian==2.3.0
 django-guid==2.2.1
-django-import-export==2.5.0
+django-import-export==2.4.0
 django-lifecycle==0.8.1
 django-readonly-field==1.0.5
 djangorestframework==3.12.2


### PR DESCRIPTION
Reverts Kong/docker-pulp#15

django-import-export 2.4.0 is needed by pulp core.