### PR TITLE
Revert "Bump idna from 2.10 to 3.1 in /pulp-core"

### DIFF
--- a/pulp-core/requirements.txt
+++ b/pulp-core/requirements.txt
@@ -42,7 +42,7 @@ ecdsa==0.13.3
 et-xmlfile==1.0.1
 future==0.18.2
 gunicorn==20.0.4
-idna==3.1
+idna==2.10
 inflection==0.5.1
 Jinja2==2.11.3
 jmespath==0.10.0


### PR DESCRIPTION
Reverts Kong/docker-pulp#17

pulp-core needs the older idna version