### PR TITLE
Revert "Bump boto3 from 1.17.54 to 1.17.61 in /pulp-core"

### DIFF
--- a/pulp-core/requirements.txt
+++ b/pulp-core/requirements.txt
@@ -17,7 +17,7 @@ async-timeout==3.0.1
 asyncio-throttle==1.0.2
 attrs==20.3.0
 backoff==1.10.0
-boto3==1.17.61
+boto3==1.17.54
 botocore==1.20.54
 certifi==2020.12.5
 cffi==1.14.5


### PR DESCRIPTION
Reverts Kong/docker-pulp#67

```
#15 11.14 ERROR: Cannot install -r /opt/pulp/pulp-requirements.txt (line 20) and botocore==1.20.54 because these package versions have conflicting dependencies.
#15 11.14 
#15 11.14 The conflict is caused by:
#15 11.14     The user requested botocore==1.20.54
#15 11.14     boto3 1.17.61 depends on botocore<1.21.0 and >=1.20.61
```