### PR TITLE
Exec rq in entrypoint

### DIFF
--- a/pulp-api/entrypoint.sh
+++ b/pulp-api/entrypoint.sh
@@ -24,6 +24,7 @@ do
   eval "args[${#args[*]}]=$arg"
 done
 
-gunicorn pulpcore.app.wsgi:application "${args[@]}" \
-          --bind "0.0.0.0:${PULP_API_BIND_PORT}" \
-          --access-logfile -
+exec gunicorn pulpcore.app.wsgi:application \
+              "${args[@]}" \
+              --bind "0.0.0.0:${PULP_API_BIND_PORT}" \
+              --access-logfile -

--- a/pulp-content/entrypoint.sh
+++ b/pulp-content/entrypoint.sh
@@ -7,8 +7,8 @@ echo "[INFO] Collecting static files"
 pulpcore-manager collectstatic --noinput
 
 echo "[INFO] Starting content server"
-gunicorn pulpcore.content:server \
-          --bind "0.0.0.0:${PULP_CONTENT_BIND_PORT}" \
-          --worker-class 'aiohttp.GunicornWebWorker' \
-          -w ${PULP_CONTENT_WORKERS} \
-          --access-logfile -
+exec gunicorn pulpcore.content:server \
+              --bind "0.0.0.0:${PULP_CONTENT_BIND_PORT}" \
+              --worker-class 'aiohttp.GunicornWebWorker' \
+              -w ${PULP_CONTENT_WORKERS} \
+              --access-logfile -

--- a/pulp-resource-manager/entrypoint.sh
+++ b/pulp-resource-manager/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
 REDIS_URL=${PULP_REDIS_URL:-"localhost:6379"}
-rq worker --url "$REDIS_URL" -n 'resource-manager' -w 'pulpcore.tasking.worker.PulpWorker' --disable-job-desc-logging
+exec rq worker --url "$REDIS_URL" -n 'resource-manager' -w 'pulpcore.tasking.worker.PulpWorker' --disable-job-desc-logging

--- a/pulp-worker/entrypoint.sh
+++ b/pulp-worker/entrypoint.sh
@@ -18,4 +18,4 @@ fi
 
 REDIS_URL=${PULP_REDIS_URL:-"localhost:6379"}
 WORKER_NAME=${WORKER_NAME:-"worker@%h"}
-rq worker --url "$REDIS_URL" -n "$WORKER_NAME" -w 'pulpcore.tasking.worker.PulpWorker' --disable-job-desc-logging
+exec rq worker --url "$REDIS_URL" -n "$WORKER_NAME" -w 'pulpcore.tasking.worker.PulpWorker' --disable-job-desc-logging


### PR DESCRIPTION
Make the entrypoint scripts exec rq at the end so sending a TERM to the container entrypoint will get that TERM delivered to the rq process cleanly. Normally, bash eats the TERM and leaves rq running as an orphan. Then when the container is cleaned up, the processes are KILL'd, which does not result in a clean exit.

Added the exec to the guniocrn in content-server and api. Unclean exit isn't as big of a deal with those, but since gunicorn also handles TERM and exits cleanly when sessions are done, it seems like a sane idea for them too.

I think tini can actually be left out as well, but we'll leave that for another day.  The entrypoint scripts do launch children.  Bash should handle them gracefully if anything usual goes wrong, but I kind of like having tini there for "safety".

Example of killing the container for the resource manager and then immediately restarting it.  Note that there is no "already a resource manager running" message; the old one signs off cleanly, and the new one starts right up.
```plain
resource-manager_1  | pulp [None]: pulpcore.tasking.worker_watcher:INFO: Worker 'resource-manager' shutdown
resource-manager_1  | pulp [None]: pulpcore.tasking.worker_watcher:INFO: Cleaning up shutdown worker 'resource-manager'.
resource-manager_1  | pulp [None]: rq.worker:INFO: Warm shut down requested
resource-manager_1  | pulp [None]: rq.worker:INFO: Unsubscribing from channel rq:pubsub:resource-manager
docker-pulp_resource-manager_1 exited with code 0
resource-manager_1  | pulp [None]: pulpcore.tasking.worker_watcher:INFO: Worker 'resource-manager' shutdown
resource-manager_1  | pulp [None]: pulpcore.tasking.worker_watcher:INFO: Cleaning up shutdown worker 'resource-manager'.
resource-manager_1  | pulp [None]: rq.worker:INFO: Worker rq:worker:resource-manager: started, version 1.8.0
resource-manager_1  | pulp [None]: rq.worker:INFO: Subscribing to channel rq:pubsub:resource-manager
resource-manager_1  | pulp [None]: rq.worker:INFO: *** Listening on resource-manager...
resource-manager_1  | pulp [None]: pulpcore.tasking.worker_watcher:INFO: Worker 'resource-manager' is back online.
```

Same situation with a worker being started up with the same hostname:
```plain
worker_1            | pulp [None]: pulpcore.tasking.worker_watcher:INFO: Worker 'worker@cfb380c11b0f' shutdown
worker_1            | pulp [None]: pulpcore.tasking.worker_watcher:INFO: Cleaning up shutdown worker 'worker@cfb380c11b0f'.
worker_1            | pulp [None]: rq.worker:INFO: Warm shut down requested
worker_1            | pulp [None]: rq.worker:INFO: Unsubscribing from channel rq:pubsub:worker@cfb380c11b0f
docker-pulp_worker_1 exited with code 0
worker_1            | pulp [None]: pulpcore.tasking.worker_watcher:INFO: Worker 'worker@cfb380c11b0f' shutdown
worker_1            | pulp [None]: pulpcore.tasking.worker_watcher:INFO: Cleaning up shutdown worker 'worker@cfb380c11b0f'.
worker_1            | pulp [None]: rq.worker:INFO: Worker rq:worker:worker@cfb380c11b0f: started, version 1.8.0
worker_1            | pulp [None]: rq.worker:INFO: Subscribing to channel rq:pubsub:worker@cfb380c11b0f
worker_1            | pulp [None]: rq.worker:INFO: *** Listening on worker@cfb380c11b0f...
worker_1            | pulp [None]: pulpcore.tasking.worker_watcher:INFO: Worker 'worker@cfb380c11b0f' is back online.
```

I'm less concerned about the web services, but for completeness...

API server:
```plain
api_1               | [2021-05-26 15:00:28 +0000] [8] [INFO] Handling signal: term
api_1               | [2021-05-26 15:00:28 +0000] [13] [INFO] Worker exiting (pid: 13)
api_1               | [2021-05-26 15:00:29 +0000] [8] [INFO] Shutting down: Master
docker-pulp_api_1 exited with code 0
```

Content server is a little less pretty, but still pretty clean
```plain
content_1           | [2021-05-26 15:01:21 +0000] [7] [INFO] Handling signal: term
content_1           | [2021-05-26 15:01:21 +0000] [9] [INFO] Worker exiting (pid: 9)
content_1           | pulp [None]: asyncio:ERROR: Task was destroyed but it is pending!
content_1           | task: <Task pending name='Task-2' coro=<_heartbeat() running at /opt/pulp/lib/python3.9/site-packages/pulpcore/content/__init__.py:42> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7faf14e4c130>()]>>
content_1           | [2021-05-26 15:01:22 +0000] [10] [INFO] Worker exiting (pid: 10)
content_1           | pulp [None]: asyncio:ERROR: Task was destroyed but it is pending!
content_1           | task: <Task pending name='Task-2' coro=<_heartbeat() running at /opt/pulp/lib/python3.9/site-packages/pulpcore/content/__init__.py:42> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7faf0eda7970>()]>>
content_1           | [2021-05-26 15:01:23 +0000] [7] [INFO] Shutting down: Master
docker-pulp_content_1 exited with code 0
```