### PR TITLE
Update autolabel action because Dependabot security

### DIFF
--- a/.github/workflows/autolabel.yaml
+++ b/.github/workflows/autolabel.yaml
@@ -2,7 +2,10 @@
 name: Pull Request Labeler
 
 on:  # yamllint disable-line rule:truthy
-  pull_request:
+  # note: security risk from this action.  Do not add
+  # actions in here which need a checkout of the repo,
+  # and do not use any caching in here.
+  pull_request_target:
 
 jobs:
   autolabel:


### PR DESCRIPTION
Dependabot runs PRs in a way that makes them appear as a fork, so as a result the pull_request action runs with a read-only token.  That breaks label creation, which is super annoying.  Switching to pull_request_target runs with a read-write token, but introduces a security risk if the action isn't careful.

The action as-is is fine, but addtions need to be careful.  Added a comment to that end.

https://github.com/actions/labeler/issues/136
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target