### PR TITLE
Stop using env at top level environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,9 @@ on:  # yamllint disable-line rule:truthy
     - .github/**
 
 env:
-  BUILD_CACHE: ${{ env.GITHUB_WORKSPACE }}/../imagecache
-  CACHE_KEY: ${{ env.GITHUB_WORKFLOW }}  # TODO: hash the Dockerfile here
+  #BUILD_CACHE: ${{ env.GITHUB_WORKSPACE }}/../imagecache # no env. contenxt at top level :/
+  BUILD_CACHE: /tmp/imagecache
+  CACHE_KEY: ${{ hashFiles("pulp-core/Dockerfile") }}
   CORE_CACHEFILE: pulp_core.tar
   CORE_CACHETAG: buildcache
 


### PR DESCRIPTION
Github does not allow you to reference environment variables from the workflow top-level env definition; only from lower-level env blocks.  Sigh.