### PR TITLE
Stop using hashFiles function

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,16 +16,18 @@ env:
   #BUILD_CACHE: ${{ env.GITHUB_WORKSPACE }}/../imagecache # no env. contenxt at top level :/
   BUILD_CACHE: /tmp/imagecache
   CORE_CACHEFILE: pulp_core.tar
+  IMAGE_ARTIFACT: pulp_images.tar
 
 jobs:
   build:
     name: Build containers
     runs-on: ubuntu-latest
     env:
-      BUILD_TAG: ${{ github.job }}
+      # use per-run tag for build, but consistent tag for cache purposes
+      BUILD_TAG: ${{ github.job }}.${{ github.run_id }}
       CACHE_TAG: buildcache
     outputs:
-      cache_tag: ${{ env.BUILD_TAG }}
+      cache_tag: ${{ env.CACHE_TAG }}
       cache_key: ${{ env.CACHE_KEY }}
     steps:
     - uses: actions/checkout@v2.3.4
@@ -35,12 +37,13 @@ jobs:
       run: |
         if [[ -f "$FILE_TO_HASH" ]]
         then
-          printf "CACHE_KEY=%s\n" '${{ hashFiles(${{ env.FILE_TO_HASH }}) }}' >> $GITHUB_ENV
+          # you can't use the env context as an arg for hashFiles, but it just does a sha256 :/
+          printf "CACHE_KEY=pulp.%s\n" $(sha256sum "$FILE_TO_HASH" | awk '$0=$1') >> $GITHUB_ENV
         else
           echo "Misisng '$FILE_TO_HASH'; this will probably fail later but setting default key anyway"
           printf "CACHE_KEY=HoorayForDanny\n" >> $GITHUB_ENV
         fi
-    - uses: actions/cache@2.1.6
+    - uses: actions/cache@v2.1.6
       id: cache
       with:
         path: ${{ env.BUILD_CACHE }}
@@ -49,10 +52,13 @@ jobs:
     - name: Import cached image
       if: ${{ steps.cache.outputs.cache-hit }}
       run: |
-        if -f [[ "$CORE_CACHEFILE" ]]
+        OUTFILE="$BUILD_CACHE/$CORE_CACHEFILE"
+        if [[ -f "$OUTFILE" ]]
         then
-          docker import "$CORE_CACHEFILE"
+          printf "Importing $OUTFILE\n"
+          docker import "$OUTFILE"
         fi
+        docker images
         true
     - name: Build job-specific image
       env:
@@ -62,35 +68,36 @@ jobs:
         IS_PREBUILD: 1
       run: |
         make images
+        # make these vars usable in later steps
+        for V in ORG TAG
+        do
+          printf "%s=%s\n" "$V" "${!V}"
+        done >> $GITHUB_ENV
     - name: Export image to cache
+      # don't bother exporting, since the cache won't be updated if hit :/
+      #if: !${{ steps.cache.outputs.cache-hit }}
       run: |
         mkdir -p "$BUILD_CACHE"
+        cd "$BUILD_CACHE"
         # retag with common tag for future builds
-        docker tag "$ORG/pulp-core:$TAG" "$ORG/pulp-core:$CACHE_TAG"
-        docker export --output="$CORE_CACHEFILE" "$ORG/pulp-core:$CACHE_TAG"
+        SPECIAL_IMAGE="$ORG/pulp-core:$CACHE_TAG"
+        docker tag "$ORG/pulp-core:$TAG" "$SPECIAL_IMAGE"
+        docker save --output="$CORE_CACHEFILE" "$SPECIAL_IMAGE"
     - name: Export images for artifact
       id: artifact_export
       run: |
-        OUT=$( mktemp -d )
-        # export built images
-        for I in pulp-{api,content,worker,resource-manager}
-        do
-          docker export --output="$OUT/${I}.tar" "$ORG/${I}:$CACHE_TAG"
-        done
-        printf '::set-output name=imagedir::%s/\n' "$OUT"
+        docker save --output="$IMAGE_ARTIFACT" $( docker images --format '{{.Repository}}:{{.Tag}}' "$ORG/*:$TAG" )
     - name: Save build artifact
       uses: actions/upload-artifact@v2.2.4
       with:
         name: images
-        path: ${{ steps.artifact_export.outputs.imagedir }}
+        path: ${{ env.IMAGE_ARTIFACT }}
 
   release:
     name: Create Github Release
     needs: build
     if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
     runs-on: ubuntu-latest
-    env:
-      CACHE_KEY: ${{ jobs.build.outputs.cache_key }}
     outputs:
       tag: ${{ steps.versioning.outputs.version }}
     steps:
@@ -98,10 +105,10 @@ jobs:
       uses: actions/checkout@v2.3.4
       with:
         fetch-depth: 0 # need all refs for tag generation
-    - uses: actions/cache@2.1.6
+    - uses: actions/cache@v2.1.6
       with:
         path: ${{ env.BUILD_CACHE }}
-        key: ${{ env.CACHE_KEY   }}
+        key: ${{ needs.build.outputs.cache_key }}
 
     - name: Auto Increment Semver Action
       uses: MCKanpolat/auto-semver-action@1.0.7
@@ -131,20 +138,18 @@ jobs:
     name: Publish Release
     needs: release
     runs-on: ubuntu-latest
-    env:
-      CACHE_KEY: ${{ jobs.build.outputs.cache_key }}
     strategy:
       matrix:
         tag:
-        - ${{ jobs.release.outputs.tag }}
+        - ${{ needs.release.outputs.tag }}
         - latest
     steps:
     - uses: actions/checkout@v2.3.4
-    - uses: actions/cache@2.1.6
+    - uses: actions/cache@v2.1.6
       id: cache
       with:
         path: ${{ env.BUILD_CACHE }}
-        key: ${{ env.CACHE_KEY   }}
+        key: ${{ needs.build.outputs.cache_key }}
     - name: Login to DockerHub
       uses: docker/login-action@v1.10.0
       with:
@@ -159,12 +164,14 @@ jobs:
         DOCKER_BUILDKIT: 1
         ORG: kong
         TAG: ${{ matrix.tag }}
-        CACHE_TAG: ${{ jobs.build.cache_tag }}
+        CACHE_TAG: ${{ needs.build.cache_tag }}
       run: |
         make images
+        # make these vars usable in later steps
+        for V in ORG TAG
+        do
+          printf "%s=%s\n" "$V" "${!V}"
+        done >> $GITHUB_ENV
     - name: Publish images
-      env:
-        ORG: kong
-        TAG: ${{ matrix.tag }}
       run: |
         make release


### PR DESCRIPTION
The actions `hashFiles` function does not work with the env context, so throw that garbage on the floor and just use sha256sum with a shell var.  Same checksum as hashFiles would generate, but actually supports env vars.

Also stop trying to use previous job output as an env var in subsequent jobs, because apparently that context also isn't available in jobs.env.  The value is only used once per later job, so just directly use actions substitution instead of a more-readable env var.  Siiiigggghhhhhh.