### PR TITLE
Clean up old artifacts in actions

### DIFF
--- a/.github/workflows/remove-old-artifacts.yml
+++ b/.github/workflows/remove-old-artifacts.yml
@@ -1,0 +1,21 @@
+---
+name: Remove old artifacts
+
+on:  # yamllint disable-line rule:truthy
+  # Every day at 1am
+  schedule:
+  - cron: 0 1 * * *
+
+jobs:
+  remove-old-artifacts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - name: Remove old artifacts
+      uses: c-hive/gha-remove-artifacts@v1.2.0
+      with:
+        age: 1 month
+        # Optional inputs
+        # skip-tags: true
+        skip-recent: 3


### PR DESCRIPTION
We save the generated images when building Docker.  That can quickly use a whole lot of space.  Start with the basic action straight out of the https://github.com/marketplace/actions/remove-artifacts documentation, with "keep most recent 3" also enabled.