### PR TITLE
Add explicit needs on final step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
 
   publish:
     name: Publish Release
-    needs: [build, release] 
+    needs: [build, release]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
 
   publish:
     name: Publish Release
-    needs: release
+    needs: [build, release] 
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
I'm just guessing here, but it appears the `needs` line must have explicit dependencies in it for the relevant step outputs to be available.

The same key definition line works fine in a prior step, so it must be that the needs.X isn't populated for any X which isn't explicitly listed in the `needs` stanza for a job. It was implicitly required, but maybe recursion is too hard for Github. :) 

(if this fixes it, I'll open a bug that they can ignore) 