### PR TITLE
pre-create workdir

### DIFF
--- a/pulp-core/Dockerfile
+++ b/pulp-core/Dockerfile
@@ -70,7 +70,8 @@ COPY sign-metadata.sh /opt/pulp/bin/sign-metadata
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/local/bin/tini
 RUN chmod +x /usr/local/bin/tini && \
-    useradd --system -m -d /var/lib/pulp -s /sbin/nologin pulp
+    useradd --system -m -d /var/lib/pulp -s /sbin/nologin pulp && \
+    mkdir -p /var/lib/pulp/tmp && chown pulp /var/lib/pulp/tmp
 
 # TODO: mount=type=bind,from=build,source=/var/cache/dnf,target=/var/cache/dnf,rw
 # This won't work due to the "clean all", but removing that needs --squash


### PR DESCRIPTION
Sometimes pulp seems to fail creating /var/lib/pulp/tmp, so just create it in the container to begin with.

Alternative is to set PULP_WORKDIR in the helm chart's environment, but this makes more sense for our k8s deployment.
ref: https://pulp.plan.io/issues/4602