### PR TITLE
Revert "Bump boto3 from 1.18.24 to 1.18.33 in /pulp-core"

### DIFF
--- a/pulp-core/requirements.txt
+++ b/pulp-core/requirements.txt
@@ -19,7 +19,7 @@ async-timeout==3.0.1
 asyncio-throttle==1.0.2
 attrs==21.2.0
 backoff==1.10.0
-boto3==1.18.33
+boto3==1.18.24
 botocore==1.21.31
 certifi==2021.5.30
 cffi==1.14.6


### PR DESCRIPTION
Reverts Kong/docker-pulp#172

There was an error in the required checks; "build" wasn't actually required, which resulted in this getting automerged incorrectly. :D 