### PR TITLE
Enable manual release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
   release:
     name: Create Github Release
     needs: build
-    if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+    if: ${{ github.ref == 'refs/heads/main' && ( github.event_name == 'push' || github.event_name == 'workflow_dispatch' ) }}
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.versioning.outputs.version }}


### PR DESCRIPTION
The workflow_dispatch action doesn't generate a release presently.  It'd be handy if releases were generated when this was manually run on main.