### PR TITLE
Temporarily disable container support

### DIFF
--- a/pulp-core/requirements.txt
+++ b/pulp-core/requirements.txt
@@ -1,7 +1,7 @@
 # modules to install in core container
 pulpcore==3.14.7
 pulp-file==1.8.2
-pulp-container==2.8.1
+#pulp-container==2.8.1
 pulp-rpm==3.14.6
 pulp-deb==2.14.1
 # django-storages[boto3] gets magically expanded by pip freeze


### PR DESCRIPTION
Bug was fixed in https://github.com/pulp/pulp_container/commit/7737a9fe19eb555af2b748958dceb0ca43455b2f, but that's only in the 2.9.x branch which requires a newer pulpcore.  We can reenable the container plugin when we update core.