### PR TITLE
fix(deb): adapt sign script for deb signing

### DIFF
--- a/pulp-core/sign-metadata.sh
+++ b/pulp-core/sign-metadata.sh
@@ -2,19 +2,50 @@
 
 FILE_PATH=$1
 SIGNATURE_PATH="$FILE_PATH.asc"
-PUBLIC_KEY=/tmp/public.key
+DETACHED_SIGNATURE_PATH="Release.gpg"
+INLINE_SIGNATURE_PATH="InRelease"
 
 export GNUPGHOME=/var/lib/pulp/.gnupg
 ADMIN_ID=$(gpg --list-keys --with-colons | grep fpr: | head -n1 | cut -d: -f10)
 
+COMMON_GPG_OPTS="--batch --armor "
+
 # Create a detached signature
-gpg --quiet --batch --pinentry-mode loopback --yes --detach-sign -u "$ADMIN_ID" \
-   --armor --output "$SIGNATURE_PATH" "$FILE_PATH"
+ /usr/bin/gpg "${COMMON_GPG_OPTS}" \
+    --pinentry-mode loopback \
+    --yes \
+    --detach-sign \
+    --output "${SIGNATURE_PATH}" \
+    --local-user "${ADMIN_ID}" \
+    "${FILE_PATH}"
+
+# Create an inline signature
+/usr/bin/gpg "${COMMON_GPG_OPTS}" \
+    --clearsign \
+    --output "${INLINE_SIGNATURE_PATH}" \
+    --local-user "${ADMIN_ID}" \
+    "${FILE_PATH}"
+
+# Deb Repositories want the detached-signature with a certain name
+/usr/bin/cp "${SIGNATURE_PATH}" "${DETACHED_SIGNATURE_PATH}"
+
+json=$(cat <<-"END"
+    {
+        "file": "${FILE_PATH}",
+        "signature": "${SIGNATURE_PATH}",
+        "key": "/tmp/public.key",
+        "signatures": {
+            "inline": "${INLINE_SIGNATURE_PATH}",
+            "detached": "${DETACHED_SIGNATURE_PATH}"
+        }
+    }
+END
+)
 
 # Check the exit status
 STATUS=$?
 if [[ $STATUS -eq 0 ]]; then
-    printf '{"file": "%s", "signature": "%s", "key" : "%s"}\n' "$FILE_PATH" "$SIGNATURE_PATH" "$PUBLIC_KEY"
+    echo "${json}"
 else
     exit $STATUS
 fi


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jaiks@posteo.de>

[The AptReleaseSigningService needs `signatures` in the json output in order to function.](https://github.com/pulp/pulp_deb/blob/main/pulp_deb/app/models/signing_service.py#L43-L69)


